### PR TITLE
Pass domain_name when authenticating via websso

### DIFF
--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -136,9 +136,10 @@ def websso(request):
     referer = request.META.get('HTTP_REFERER', settings.OPENSTACK_KEYSTONE_URL)
     auth_url = re.sub(r'/auth.*', '', referer)
     token = request.POST.get('token')
+    domain_name = request.POST.get('domain_name')
     try:
         request.user = auth.authenticate(request=request, auth_url=auth_url,
-                                         token=token)
+                                         token=token, user_domain_name=domain_name)
     except exceptions.KeystoneAuthException as exc:
         msg = 'Login failed: %s' % unicode(exc)
         res = django_http.HttpResponseRedirect(settings.LOGIN_URL)


### PR DESCRIPTION
The domain_name is passed along with the token from keystone and needs to passed to `auth.authenticate` in order for the domain token to be set up properly.

This is one of three changesets necessary to address https://www.pivotaltracker.com/story/show/95561536, including changes to sungardas-horizon and keystone.
