### PR TITLE
Don't revoke domain token when switching projects

### DIFF
--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -206,6 +206,20 @@ def delete_token(endpoint, token_id):
         LOG.info('Could not delete token')
 
 
+def should_revoke_old_token(request, old_token, old_endpoint, auth_ref):
+    # Don't revoke if no token defined
+    if not old_token or not old_endpoint:
+        return False
+    # Don't revoke if new token is the same as the old token
+    if old_token.id == auth_ref.auth_token:
+        return False
+    # Don't revoke if this token is the domain token
+    domain_token_id = request.session.get('domain_token')['auth_token']
+    if old_token.id == domain_token_id:
+        return False
+    return True
+
+
 @login_required
 def switch(request, tenant_id, redirect_field_name=auth.REDIRECT_FIELD_NAME):
     """Switches an authenticated user from one project to another."""
@@ -243,7 +257,7 @@ def switch(request, tenant_id, redirect_field_name=auth.REDIRECT_FIELD_NAME):
     if auth_ref:
         old_endpoint = request.session.get('region_endpoint')
         old_token = request.session.get('token')
-        if old_token and old_endpoint and old_token.id != auth_ref.auth_token:
+        if should_revoke_old_token(request, old_token, old_endpoint, auth_ref):
             delete_token(endpoint=old_endpoint, token_id=old_token.id)
         user = auth_user.create_user_from_token(
             request,


### PR DESCRIPTION
If the user was not previously assigned to a project, the session token will be the domain token instead of a project token. In that case, don't revoke the token. If the domain token is revoked, any subsequent keystone calls will fail.

Necessary in pursuit of #96789168
